### PR TITLE
appdata: Add cvs-browser url

### DIFF
--- a/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
+++ b/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
@@ -77,6 +77,7 @@
   <url type="help">https://github.com/gdm-settings/gdm-settings/wiki</url>
   <url type="translate">https://hosted.weblate.org/engage/gdm-settings</url>
   <url type="donation">https://gdm-settings.github.io/donate</url>
+  <url type="vcs-browser">https://github.com/gdm-settings/gdm-settings</url>
 
   <!-- Note: AppStream docs recommend keeping notes of old versions -->
   <releases>


### PR DESCRIPTION
This URL is visible on Flathub and GNOME Software.