### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
+++ b/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
@@ -46,6 +46,8 @@
     <binary>gdm-settings</binary>
   </provides>
 
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
+  <developer_name>Mazhar Hussain</developer_name>
   <developer id="realmazharhussain.github.io">
       <name>Mazhar Hussain</name>
   </developer>

--- a/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
+++ b/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
@@ -24,14 +24,6 @@
     <value key="GnomeSoftware::key-colors">[(100, 180, 255), (50, 100, 200)]</value>
   </custom>
 
-  <categories>
-    <category>GNOME</category>
-    <category>GTK</category>
-    <category>System</category>
-    <category>Settings</category>
-    <category>DesktopSettings</category>
-  </categories>
-
   <supports>
     <control>pointing</control>
     <control>keyboard</control>


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Mark the `<developer_name>` tag as deprecated

### appdata: Remove categories

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories