### PR TITLE
fix inconsistent quotes in `__init__.py`

### DIFF
--- a/gdms/__init__.py
+++ b/gdms/__init__.py
@@ -11,7 +11,7 @@ from enum import Enum
 from gettext import gettext as _
 
 import gi
-gi.require_version("Adw", '1')
+gi.require_version('Adw', '1')
 
 from . import config
 
@@ -21,8 +21,8 @@ from . import config
 APP_DIR = os.path.realpath(__file__).split(config.prefix)[0]
 
 _localedir = APP_DIR + config.localedir
-locale.bindtextdomain("gdm-settings", _localedir)
-locale.textdomain("gdm-settings")
+locale.bindtextdomain('gdm-settings', _localedir)
+locale.textdomain('gdm-settings')
 gettext.bindtextdomain('gdm-settings', _localedir)
 gettext.textdomain('gdm-settings')
 


### PR DESCRIPTION
It's weird to see different quotes used for the same things, so I fixed it.

If there's a style/formatting rule that specifies which string-literals should use double-quotes, please let me know, because I found none