### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
+++ b/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
@@ -84,7 +84,7 @@
   <releases>
     <release version="4.3" type="stable" date="2024-02-25">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.3</url>
-      <description translatable="no">
+      <description translate="no">
         <p>Improved brand colors for this app on GNOME Software and added brand
            colors for this app on other software centers.</p>
       </description>
@@ -92,7 +92,7 @@
 
     <release version="4.2" type="stable" date="2024-02-25">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.2</url>
-      <description translatable="no">
+      <description translate="no">
         <p>Fixed "About" window crashing, some icons being colored in the sidebar, and
            "Apply current display settings" not working properly. Improved app store
            page (a.k.a metainfo). Added a mneumonic to the "Apply" button (It can be
@@ -106,7 +106,7 @@
 
     <release version="4.1" type="stable" date="2023-10-22">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.1</url>
-      <description translatable="no">
+      <description translate="no">
         <p>Fixed "Apply current display settings" feature not working</p>
       </description>
 
@@ -117,7 +117,7 @@
 
     <release version="4.0" type="stable" date="2023-10-21">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.0</url>
-      <description translatable="no">
+      <description translate="no">
         <p>GDM Settings 4 brings</p>
         <ul>
           <li>New UI style</li>
@@ -138,7 +138,7 @@
 
     <release version="4~beta1" type="development" date="2023-10-03">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.beta1</url>
-      <description translatable="no">
+      <description translate="no">
         <p>Workaround Flathub's annoying behavior of silently stripping out some app info</p>
       </description>
     </release>
@@ -146,7 +146,7 @@
     <release version="4~beta0" type="development" date="2023-09-29">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.beta0</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p>First beta release of the upcoming GDM Settings version 4</p>
         <ul>
           <li>New UI style</li>
@@ -167,7 +167,7 @@
     <release version="3.3" type="stable" date="2023-08-13">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.3</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p>Fixed:</p>
         <ul>
           <li>Changing background color doesn't work on GNOME 44</li>
@@ -183,7 +183,7 @@
     <release version="3.2" type="stable" date="2023-06-22">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.2</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p>Fixed: Changing background doesn't work on GNOME 44</p>
       </description>
 
@@ -199,7 +199,7 @@
     <release version="3.0" type="stable" date="2023-04-13">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.0</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p><em>New Options</em></p>
         <ul>
           <li>Option to disable accessiblitly menu when not being used</li>
@@ -225,7 +225,7 @@
     <release version="3~beta.0" type="development" date="2023-03-23">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.beta.0</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p>Fixed: Fails to run on PureOS</p>
       </description>
 
@@ -237,7 +237,7 @@
     <release version="3~alpha.0" urgency="medium" type="development" date="2023-02-24">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.alpha.0</url>
 
-      <description translatable="no">
+      <description translate="no">
         <p><em>New Options</em></p>
         <ul>
           <li>Option to disable accessiblitly menu when not being used</li>

--- a/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
+++ b/data/io.github.realmazharhussain.GdmSettings.metainfo.xml.in
@@ -84,7 +84,7 @@
   <releases>
     <release version="4.3" type="stable" date="2024-02-25">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.3</url>
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Improved brand colors for this app on GNOME Software and added brand
            colors for this app on other software centers.</p>
       </description>
@@ -92,7 +92,7 @@
 
     <release version="4.2" type="stable" date="2024-02-25">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.2</url>
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Fixed "About" window crashing, some icons being colored in the sidebar, and
            "Apply current display settings" not working properly. Improved app store
            page (a.k.a metainfo). Added a mneumonic to the "Apply" button (It can be
@@ -106,7 +106,7 @@
 
     <release version="4.1" type="stable" date="2023-10-22">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.1</url>
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Fixed "Apply current display settings" feature not working</p>
       </description>
 
@@ -117,7 +117,7 @@
 
     <release version="4.0" type="stable" date="2023-10-21">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.0</url>
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>GDM Settings 4 brings</p>
         <ul>
           <li>New UI style</li>
@@ -138,7 +138,7 @@
 
     <release version="4~beta1" type="development" date="2023-10-03">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.beta1</url>
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Workaround Flathub's annoying behavior of silently stripping out some app info</p>
       </description>
     </release>
@@ -146,7 +146,7 @@
     <release version="4~beta0" type="development" date="2023-09-29">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v4.beta0</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>First beta release of the upcoming GDM Settings version 4</p>
         <ul>
           <li>New UI style</li>
@@ -167,7 +167,7 @@
     <release version="3.3" type="stable" date="2023-08-13">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.3</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Fixed:</p>
         <ul>
           <li>Changing background color doesn't work on GNOME 44</li>
@@ -183,7 +183,7 @@
     <release version="3.2" type="stable" date="2023-06-22">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.2</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Fixed: Changing background doesn't work on GNOME 44</p>
       </description>
 
@@ -199,7 +199,7 @@
     <release version="3.0" type="stable" date="2023-04-13">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.0</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p><em>New Options</em></p>
         <ul>
           <li>Option to disable accessiblitly menu when not being used</li>
@@ -225,7 +225,7 @@
     <release version="3~beta.0" type="development" date="2023-03-23">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.beta.0</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p>Fixed: Fails to run on PureOS</p>
       </description>
 
@@ -237,7 +237,7 @@
     <release version="3~alpha.0" urgency="medium" type="development" date="2023-02-24">
       <url>https://github.com/gdm-settings/gdm-settings/releases/tag/v3.alpha.0</url>
 
-      <description translate="no">
+      <description translatable="no" translate="no">
         <p><em>New Options</em></p>
         <ul>
           <li>Option to disable accessiblitly menu when not being used</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html